### PR TITLE
Backup lookup for ARB transaction results and a few other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Advanced slippage handling has been added to the code. USE AT YOUR OWN RISK! To 
 Simple BPS slippage. The slippage is set in the Jupiter SDK. Make sure your percentage profit is a few points above the slippage. For instance 0.1% profit would need to have a slippage BPS below 10 to break even. Best to leave a little wiggle rooom for safety as low liquidity can cause your result to be a new netagive. Always test and check to make sure you are trading in a pair that can support the size you are swapping.
 
 
+
 ## Speed of Lookups
 
 One way you can speed up the lookup of the bot is to disable unused routes or ones that are too slow to be meaningful. Be careful here as you do not want to turn off the wrong ones. You can check with Birdeye and Jupiter front end to see the main pools and then do an analysis of the key ones for the pair you are swapping. Others can be turned off to gain some speed. Always test with a small amount and expect you will LOSE to begin with if you turn off so many you access only low liquidity pools. Edit at your own RISK.
@@ -231,11 +232,12 @@ To turn one **off**, set the value to **true**
                         'Unknown': true			
 			}
 
+
 ## Pro ARB trading configurations
 
-In some circumstances -- when speed is a key element to the success of ARB trading specifically, enabling the setting `onlyDirectRoutes: true` may be an option to try. It is possible this can help make things route faster. It definitely does not guarantee the best route so always test with a very small amount and use at your own risk. Setting it on the wrong pair can cause you to lose tokens. 
+In some circumstances -- when speed is a key element to the success of ARB trading, enabling the setting `onlyDirectRoutes: true` may be an option to test. This feature limits the available routes supplied via the JUP4 SDK to a subset of what is available by only returning direct routes.
 
-This feature limits the available routes supplied via the JUP4 SDK to a subset of what is available and only returning direct routes. Again, this should only be enabled with proper testing to ensure the routes and pools are sufficient for the amount you are trading. 
+It is possible this can help make things route faster and cnvert more trades. It definitely does not guarantee the best route.  You need to ensure the routes and pools are sufficient for the amount you are trading. So **always test** with a very small amount and **use at your own risk**. Setting it on the wrong pair can cause you to lose tokens. 
 
 This setitng van be found in the ./src/bot/index.js file as shown below:
 

--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ To turn one **off**, set the value to **true**
 
 ## Pro ARB trading configurations
 
-In some circumstances -- when speed is a key element to the success of ARB trading, enabling the setting `onlyDirectRoutes: true` may be an option to test. This feature limits the available routes supplied via the JUP4 SDK to a subset of what is available by only returning direct routes.
+In some circumstances -- when speed is a key element to the success of ARB trading, enabling the setting `onlyDirectRoutes: true` may be an option to explore. This feature limits the available routes supplied via the JUP4 SDK to a subset of what is available by only returning direct routes.
 
-It is possible this can help make things route faster and cnvert more trades. It definitely does not guarantee the best route.  You need to ensure the routes and pools are sufficient for the amount you are trading. So **always test** with a very small amount and **use at your own risk**. Setting it on the wrong pair can cause you to lose tokens. 
+It is possible this can help make things route faster and convert more trades. It definitely does not guarantee the best route.  You need to ensure the routes and pools are sufficient for the amount you are trading. So **always test** with a very small amount and **use at your own risk**. Setting it on the wrong pair can cause you to lose tokens. 
 
-This setitng van be found in the ./src/bot/index.js file as shown below:
+This setting can be found in the ./src/bot/index.js file as shown below:
 
 	const routes = await jupiter.computeRoutes({
 		inputMint: new PublicKey(inputToken.address),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "solana-jupiter-bot",
-	"version": "0.1.70-beta-jupv4",
+	"version": "0.1.71-beta-jupv4",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -205,7 +205,7 @@ const pingpongStrategy = async (jupiter, tokenA, tokenB) => {
 					error: tx.error?.message || null,
 				};
 
-				var waittime = await waitabit(250);
+				var waittime = await waitabit(100);
 
 				// handle TX results
 				if (tx.error) {
@@ -403,7 +403,7 @@ const arbitrageStrategy = async (jupiter, tokenA) => {
 				// stop refreshing status
 				clearInterval(printTxStatus);
 
-				//console.log('Calculate trade profit Out');
+				// Calculate the profit of the trade
 				const profit = calculateProfit(tradeEntry.inAmount, tx.outputAmount);
 
 				tradeEntry = {

--- a/src/bot/swap.js
+++ b/src/bot/swap.js
@@ -34,7 +34,7 @@ const swap = async (jupiter, route) => {
 		if (process.env.DEBUG) storeItInTempAsJSON("result", result);
 
 		// Reset counter on success
-		cache.tradeCounter.Failedbalancecheck = 0;
+		cache.tradeCounter.failedbalancecheck = 0;
 		cache.tradeCounter.errorcount = 0;
 
 		const performanceOfTx = performance.now() - performanceOfTxStart;
@@ -62,12 +62,12 @@ const failedSwapHandler = async(tradeEntry, inputToken, tradeAmount) => {
 	var realbalanceToken = await balanceCheck( inputToken );
 
 	if (realbalanceToken<tradeAmount){
-		cache.tradeCounter.Failedbalancecheck++;
+		cache.tradeCounter.failedbalancecheck++;
 
-		if (cache.tradeCounter.Failedbalancecheck>3){
+		if (cache.tradeCounter.failedbalancecheck>3){
 			// Has to fail for 3 times before it ends the script. This is to cover cases where there is a delay in account updating pull
 			console.log('Balance Lookup is too low for token: '+realbalanceToken+' < '+tradeAmount);
-			console.log('Failed For: '+cache.tradeCounter.Failedbalancecheck+' times');
+			console.log('Failed For: '+cache.tradeCounter.failedbalancecheck+' times');
 			process.exit();
 		}
 	}

--- a/src/bot/swap.js
+++ b/src/bot/swap.js
@@ -139,12 +139,11 @@ const successSwapHandler = async (tx, tradeEntry, tokenA, tokenB) => {
 		}
 		if (cache.config.tradingStrategy === "arbitrage") {
 			/** check real amounts because Jupiter SDK returns wrong amounts
-			 *  when we trading TokenA <> TokenA (arbitrage)
+			 *  when trading ARB TokenA <> TokenA (arbitrage)
 			 */
 
 			try {
 				// BETA LOOKUP FOR RESULT VIA RPC
-				//try catch error handling
 				var txresult = [];
 				var err2 = -1;
 				var rcount = 0;
@@ -152,19 +151,18 @@ const successSwapHandler = async (tx, tradeEntry, tokenA, tokenB) => {
 
 				const fetcher = async (retry) => {
 
-					console.log('Looking for result via RPC.');
+					console.log('Looking for ARB trade result via RPC.');
 					rcount++;
 
 					if (rcount>=retries){
 						// Exit max retries
-						console.log(`Max attempts to fetch transaction. Assuming it did not complete.`);
+						console.log(`Reached max attempts to fetch transaction. Assuming it did not complete.`);
 						return -1;
 					}
 
+					// Get the results of the transaction from the RPC
+					// Sometimes this takes time for it to post so retry logic is implemented
 					[txresult, err2] = await checktrans(tx?.txid,cache.walletpubkeyfull);
-					//console.log(`After txresult ERR:${err2}`);
-					//console.log(txresult);
-					//console.log(tokenA.address);
 					
 					if (err2==0 && txresult) {
 						if (txresult?.[tokenA.address]?.change>0) {
@@ -225,7 +223,6 @@ const successSwapHandler = async (tx, tradeEntry, tokenA, tokenB) => {
 					// Track the output amount
 					inputamt = txresult[tokenA.address].start;
 					outputamt = txresult[tokenA.address].end;
-					//console.log(`Succss Lookup ${inputamt} to ${outputamt}`);
 
 					cache.currentProfit.tokenA = calculateProfit(
 							cache.initialBalance.tokenA,

--- a/src/bot/ui/printToConsole.js
+++ b/src/bot/ui/printToConsole.js
@@ -161,7 +161,7 @@ function printToConsole({
 			// Show pubkey for identification of bot instance
 			const pubkey = cache.ui.hideRpc ? 'hidden' : cache.walletpubkey;
 
-			ui.div(`ARB PROTOCOL ${package.version} - ${pubkey}`);
+			ui.div(`ARB PROTOCOL ${package.version} - (${pubkey})`);
 			ui.div(chalk.gray("-".repeat(140)));
 
 			ui.div(

--- a/src/bot/ui/printToConsole.js
+++ b/src/bot/ui/printToConsole.js
@@ -5,6 +5,7 @@ const chart = require("asciichart");
 const JSBI = require('jsbi');
 
 const { toDecimal } = require("../../utils");
+const package = require("../../../package.json");
 const cache = require("../cache");
 
 function printToConsole({
@@ -160,7 +161,7 @@ function printToConsole({
 			// Show pubkey for identification of bot instance
 			const pubkey = cache.ui.hideRpc ? 'hidden' : cache.walletpubkey;
 
-			ui.div("ARB PROTOCOL V1.5 - ("+pubkey+")");
+			ui.div(`ARB PROTOCOL ${package.version} - ${pubkey}`);
 			ui.div(chalk.gray("-".repeat(140)));
 
 			ui.div(

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -8,7 +8,8 @@ cache.config = loadConfigFile({ showSpinner: true });
 
 // Adding a backup option for the transaction lookup
 // This is only needed for some RPCS that are not 
-// working up to speed.
+// working or are behind at the time of lookup.
+const rpc_main = cache.config.rpc[0];
 const rpc_backup = 'https://api.mainnet-beta.solana.com';
 
 // Key variables
@@ -31,7 +32,7 @@ const waitabit = async (ms) => {
 };
 
 // Main RPC
-const connection = new Connection(cache.config.rpc[0], {
+const connection = new Connection(rpc_main, {
     disableRetryOnRateLimit: true,
     commitment: 'confirmed',
 });

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -84,6 +84,11 @@ const checktrans = async (txid,wallet_address) => {
                 transstatus = 1;
             }
 
+            // Check if postTokenBalances is null or empty
+            if (!transresp.meta.postTokenBalances || transresp.meta.postTokenBalances.length === 0) {
+                return [null, WAIT_ERROR_CODE];
+            }
+
             var tokenamt=0;
             var tokendec=0;
 

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -6,114 +6,146 @@ const { loadConfigFile, toNumber, calculateProfit, toDecimal } = require("./inde
 
 cache.config = loadConfigFile({ showSpinner: true });
 
-const waitabit = async (ms) => {
-	const mySecondPromise = new Promise(function(resolve,reject){
-		console.log('construct a promise...')
-		setTimeout(() => {
-			reject(console.log('Error in promise'));
-		},ms)
-	})
-  }
+// Adding a backup option for the transaction lookup
+// This is only needed for some RPCS that are not 
+// working up to speed.
+const rpc_backup = 'https://api.mainnet-beta.solana.com';
 
-  const connection = new Connection(cache.config.rpc[0], {
+// Key variables
+var transstatus = 0;
+var transid = '';
+var transresp = [];
+
+const WAIT_ERROR_CODE = 1;
+const WAIT_SUCCESS_CODE = 0;
+
+const waitabit = async (ms) => {
+    try {
+        await setTimeout(ms);
+        console.log('Waited for', ms, 'milliseconds.');
+        return WAIT_SUCCESS_CODE;
+    } catch (error) {
+        console.error('Error occurred while waiting:', error);
+        return WAIT_ERROR_CODE;
+    }
+};
+
+// Main RPC
+const connection = new Connection(cache.config.rpc[0], {
     disableRetryOnRateLimit: true,
     commitment: 'confirmed',
-  });
+});
 
-const checktrans = async (transaction,wallet_address) => {
+// Backup RPC
+const connection_backup = new Connection(rpc_backup, {
+    disableRetryOnRateLimit: false,
+    commitment: 'confirmed',
+});
 
-    var transstatus = 0;
-    var transid = '';
-    var transresp = [];
-
-    // Get the goods from the RPC
-    await connection.getParsedTransaction(transaction, {"maxSupportedTransactionVersion": 0}).then((trans) => {
-        transresp = trans;
-    });  
-
-    // Analyze the Data
+const fetchTransaction = async (rpcConnection, transaction) => {
     try {
-        var transaction_changes = [];
+        return await rpcConnection.getParsedTransaction(transaction, { "maxSupportedTransactionVersion": 0 });
+    } catch (error) {
+        // Handle errors, or let the caller handle them.
+        console.error("Error fetching transaction:", error);
+        return null;
+    }
+};
 
-        if (transresp.meta?.status.Err){
-            // Failed Transaction
-            //console.log(`STATUS ERROR. DID NOT SUCCEED #1!!! ${JSON.stringify(transresp.meta.status.Err)}`);
-            return [transresp.meta.status.err,2];
-        } else {
-            //console.log('STATUS SUCCEED!!!');
-            transstatus = 1;
+const checkTransactionStatus = async (transaction, wallet_address) => {
+    try {
+        const primaryTransaction = await fetchTransaction(connection, transaction);
+        
+        if (!primaryTransaction) {
+            // If primary RPC fails, try backup RPC
+            return await fetchTransaction(connection_backup, transaction);
         }
 
-        var tokenamt=0;
-        var tokendec=0;
-        var tokenuiAmount=0;
+        return primaryTransaction;
+    } catch (error) {
+        console.error("Error checking transaction status:", error);
+        return null;
+    }
 
-        // Outgoing SOL native mgmt
-        // Handle transfers of SOL that would not show up due to wrapping
-        if (transresp.meta.innerInstructions){
-            for (instructions of transresp.meta.innerInstructions){
-                if(instructions.instructions){
-                    for (parsed of instructions.instructions){
-                        //console.log(JSON.stringify(parsed, null, 4));
-                        if (parsed.parsed){
-                            if (parsed.parsed.type=='transferChecked'){
-                                if (parsed.parsed.info.authority==wallet_address && parsed.parsed.info.mint=='So11111111111111111111111111111111111111112'){
-                                    tokenamt = parsed.parsed.info.tokenAmount.amount;
-                                    tokendec = parsed.parsed.info.tokenAmount.decimals;
-                                    tokenuiAmount = parsed.parsed.info.tokenAmount.uiAmount;
+};
+
+const checktrans = async (txid,wallet_address) => {
+    try {
+        transresp = await checkTransactionStatus(txid, wallet_address);
+    
+        if (transresp) {
+            var transaction_changes = [];
+
+            if (transresp.meta?.status.Err){
+                // Failed Transaction
+                return [transresp.meta.status.err,2];
+            } else {
+                transstatus = 1;
+            }
+
+            var tokenamt=0;
+            var tokendec=0;
+
+            // Outgoing SOL native mgmt
+            // Handle transfers of SOL that would not show up due to wrapping
+            if (transresp.meta.innerInstructions){
+                for (instructions of transresp.meta.innerInstructions){
+                    if(instructions.instructions){
+                        for (parsed of instructions.instructions){
+                            //console.log(JSON.stringify(parsed, null, 4));
+                            if (parsed.parsed){
+                                if (parsed.parsed.type=='transferChecked'){
+                                    if (parsed.parsed.info.authority==wallet_address && parsed.parsed.info.mint=='So11111111111111111111111111111111111111112'){
+                                        tokenamt = Number(parsed.parsed.info.tokenAmount.amount);
+                                        tokendec = parsed.parsed.info.tokenAmount.decimals;
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
-        
-        // SOL Transfer handling
-        if (tokenuiAmount>0){
-            transaction_changes['So11111111111111111111111111111111111111112'] = { status: transstatus, start: tokenamt, decimals: tokendec, end: 0, change: (-1*tokenamt), changedec: (-1*tokenuiAmount) };
-        }
+            
+            // SOL Transfer handling
+            if (tokenamt>0){
+                transaction_changes['So11111111111111111111111111111111111111112'] = { status: transstatus, start: tokenamt, decimals: tokendec, end: 0, change: (-1*tokenamt) };
+            }
 
-        // Pre Token Balance Handling
-        for (token of transresp.meta.preTokenBalances){
-            if (token.owner==wallet_address){
-                transaction_changes[token.mint.toString()] = {status: transstatus, start: token.uiTokenAmount.amount, decimals: token.uiTokenAmount.decimals};
-            };
-        }
+            // Pre Token Balance Handling
+            for (token of transresp.meta.preTokenBalances){
+                if (token.owner==wallet_address){
+                    transaction_changes[token.mint.toString()] = {status: transstatus, start: token.uiTokenAmount.amount, decimals: token.uiTokenAmount.decimals};
+                };
+            }
 
-        // Post Token Handling
-        for (token of transresp.meta.postTokenBalances){
-            if (token.owner==wallet_address){
-                if (transaction_changes[token.mint].start) {
-                    // Case where token account existed already
-                    diff = Number(token.uiTokenAmount.amount)-Number(transaction_changes[token.mint].start);
-                    diffdec = toDecimal(diff,transaction_changes[token.mint].decimals);
-                    transaction_changes[token.mint] = {...transaction_changes[token.mint], end: token.uiTokenAmount.amount, change: diff, changedec: diffdec} 
-                } else {
-                    // Case where token did not exist yet
-                    // Set the initial to 0
-                    transaction_changes[token.mint] = {status: transstatus, start: 0, decimals: token.uiTokenAmount.decimals};
-                    // Calculate the difference
-                    diff = Number(token.uiTokenAmount.amount)-Number(transaction_changes[token.mint].start);
-                    diffdec = toDecimal(diff,transaction_changes[token.mint].decimals);
-                    transaction_changes[token.mint] = {...transaction_changes[token.mint], end: token.uiTokenAmount.amount, change: diff, changedec: diffdec} 
+            // Post Token Handling
+            for (token of transresp.meta.postTokenBalances){
+                if (token.owner==wallet_address){
+                    if (transaction_changes[token.mint].start) {
+                        // Case where token account existed already
+                        diff = Number(token.uiTokenAmount.amount)-Number(transaction_changes[token.mint].start);
+                        diffdec = toDecimal(diff,transaction_changes[token.mint].decimals);
+                        transaction_changes[token.mint] = {...transaction_changes[token.mint], end: token.uiTokenAmount.amount, change: diff} 
+                    } else {
+                        // Case where token did not exist yet
+                        // Set the initial to 0
+                        transaction_changes[token.mint] = {status: transstatus, start: 0, decimals: token.uiTokenAmount.decimals};
+                        // Calculate the difference
+                        diff = Number(token.uiTokenAmount.amount)-Number(transaction_changes[token.mint].start);
+                        diffdec = toDecimal(diff,transaction_changes[token.mint].decimals);
+                        transaction_changes[token.mint] = {...transaction_changes[token.mint], end: token.uiTokenAmount.amount, change: diff} 
+                    }
                 }
             }
+            return [transaction_changes, WAIT_SUCCESS_CODE];
+        } else {
+            // Transaction not found or error occurred
+            return [null, WAIT_ERROR_CODE];
         }
-
-        //console.log(transaction_changes);
-        return [transaction_changes,0];
-
     } catch(error) {
-        //console.log(`STATUS ERROR. DID NOT RESOLVE OR ERROR #2!!!`);
-        return [null,1];
+        console.error('Error checking transaction:', error);
+        return [null, WAIT_ERROR_CODE];
     }
 }
 
 module.exports = {checktrans};
-
-
-
-
-
-

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -122,7 +122,7 @@ const checktrans = async (txid,wallet_address) => {
             // Post Token Handling
             for (token of transresp.meta.postTokenBalances){
                 if (token.owner==wallet_address){
-                    if (transaction_changes[token.mint].start) {
+                    if (transaction_changes[token.mint]?.start) {
                         // Case where token account existed already
                         diff = Number(token.uiTokenAmount.amount)-Number(transaction_changes[token.mint].start);
                         diffdec = toDecimal(diff,transaction_changes[token.mint].decimals);

--- a/src/wizard/Pages/Priority.js
+++ b/src/wizard/Pages/Priority.js
@@ -90,7 +90,7 @@ function priority() {
 							onSubmit={handleCustomprioritySubmit}
 						/>
 					</Box>
-					<Text>BPS</Text>
+					<Text>micro Lamports</Text>
 				</Box>
 			)}
 		</Box>


### PR DESCRIPTION
To help with lagging RPCs I added a backup lookup for checking the results of an ARB transaction. This is needed especially when using cumulative amounts as we need the successful result for the next trade. 

The main Solana RPC was used as the backup as we are only loading one transaction here. It should be perfect to use as a default and not hit any rate limits to grab just one. It is the most reliable source for the data anyhow.